### PR TITLE
Prevent Crash

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2205,8 +2205,10 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					$this->server->getPluginManager()->callEvent($ev);
 
 					if($ev->isCancelled()){
+						if ($this->inventory !== null) {
 						$this->inventory->sendHeldItem($this);
 						break;
+						}
 					}
 
 					if($item->getId() === Item::SNOWBALL){


### PR DESCRIPTION
Katana Crash Dump Fri Nov 6 17:06:50 MSK 2015

Error: Call to a member function sendHeldItem() on null
File: /src/pocketmine/Player
Line: 2208
Type: E_ERROR

Code:
[2199]                                  }else{
[2200]                                          $item = $this->inventory->getItemInHand();
[2201]                                  }
[2202]
[2203]                                  $ev = new PlayerInteractEvent($this, $item, $aimPos, $packet->face, PlayerInteractEvent::RIGHT_CLICK_AIR);
[2204]
[2205]                                  $this->server->getPluginManager()->callEvent($ev);
[2206]
[2207]                                  if($ev->isCancelled()){
[2208]                                          $this->inventory->sendHeldItem($this);
[2209]                                          break;
[2210]                                  }
[2211]
